### PR TITLE
TEDEFO-1191 removing support of SDK 0.6

### DIFF
--- a/src/test/java/eu/europa/ted/eforms/viewer/NoticeViewerTest.java
+++ b/src/test/java/eu/europa/ted/eforms/viewer/NoticeViewerTest.java
@@ -24,6 +24,7 @@ import org.xml.sax.SAXException;
 import eu.europa.ted.eforms.sdk.SdkConstants;
 import eu.europa.ted.eforms.viewer.helpers.SdkResourceLoader;
 
+@SuppressWarnings("static-method")
 class NoticeViewerTest {
   private static final Logger logger = LoggerFactory.getLogger(NoticeViewerTest.class);
 
@@ -35,7 +36,7 @@ class NoticeViewerTest {
   private static final String[] SOURCE_NOTICE_XML_FILENAMES2 =
       new String[] {"X01_EEIG", "X02_registration"};
 
-  private static final String[] SOURCE_SDK_VERSIONS = new String[] {"0.6", "0.7", "1.0"};
+  private static final String[] SOURCE_SDK_VERSIONS = new String[] {"0.7", "1.0"};
 
   private static final String SDK_RESOURCES_ROOT =
       Path.of("target", SdkConstants.DEFAULT_SDK_ROOT).toString();


### PR DESCRIPTION
This fixes the unit tests thus also mvn clean install.
I do not think we want to support SDK 0.6 once SDK 1.0 comes out.