### PR TITLE
TEDEFO-1539 adapting the SdkSymbolResolver to load the parentId from …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- Versions - eForms -->
-    <version.efx-toolkit>1.1.1</version.efx-toolkit>
+    <version.efx-toolkit>1.1.2-SNAPSHOT</version.efx-toolkit>
     <version.eforms-core>0.1.1</version.eforms-core>
 
     <!-- Versions - Third-party libraries -->

--- a/src/main/java/eu/europa/ted/eforms/sdk/entity/SdkCodelistRepository.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/entity/SdkCodelistRepository.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -14,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.helger.genericode.Genericode10CodeListMarshaller;
 import com.helger.genericode.v10.CodeListDocument;
 import com.helger.genericode.v10.Identification;
+import com.helger.genericode.v10.LongName;
 import com.helger.genericode.v10.SimpleCodeList;
 import eu.europa.ted.eforms.sdk.helpers.GenericodeTools;
 
@@ -42,10 +45,12 @@ public class SdkCodelistRepository extends HashMap<String, SdkCodelist> {
    */
   @Override
   public final SdkCodelist get(final Object codelistId) {
+    if (codelistId == null) {
+      throw new RuntimeException("CodelistId is null.");
+    }
     if (StringUtils.isBlank((String) codelistId)) {
       throw new RuntimeException("CodelistId is blank.");
     }
-
     return computeIfAbsent((String) codelistId, key -> {
       try {
         return loadSdkCodelist(sdkVersion, key, codelistsPath);
@@ -79,13 +84,14 @@ public class SdkCodelistRepository extends HashMap<String, SdkCodelist> {
     }
     final String filename = codelistIdToFilename.get(codeListId);
     assert filename != null : "filename is null";
-    try (InputStream is = Files.newInputStream(codelistsPath)) {
+    try (InputStream is = Files.newInputStream(codelistsPath.resolve(Path.of(filename)))) {
       final CodeListDocument cl = marshaller.read(is);
       final SimpleCodeList scl = cl.getSimpleCodeList();
-      final String codelistVersion = cl.getIdentification().getVersion(); // Version
-                                                                          // tag
-                                                                          // of
-                                                                          // .gc
+
+      // Version tag of the genericode (gc) file.
+      final String codelistVersion = cl.getIdentification().getVersion();
+      final Optional<String> parentCodelistIdOpt = extractParentId(cl.getIdentification());
+
       // Get all the code values in a list.
       // We assume there are no duplicate code values in the referenced
       // codelists.
@@ -97,10 +103,34 @@ public class SdkCodelistRepository extends HashMap<String, SdkCodelist> {
             .getSimpleValue()//
             .getValue().strip();
       }).collect(Collectors.toList());
-      return SdkEntityFactory.getSdkCodelist(sdkVersion, codeListId, codelistVersion, codes);
+
+      return SdkEntityFactory.getSdkCodelist(sdkVersion, codeListId, codelistVersion, codes,
+          parentCodelistIdOpt);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /**
+   * Get eForms parent id.
+   */
+  public static final Optional<String> extractParentId(final Identification ident) {
+    return extractLongnameWithIdentifier(ident, "eFormsParentId");
+  }
+
+  /**
+   * @return The extracted value as an stripped string if present, optional empty otherwise.
+   */
+  public static Optional<String> extractLongnameWithIdentifier(final Identification identity,
+      final String identifierStr) {
+    final Optional<LongName> valueOpt = identity.getLongName().stream()
+        .filter(item -> Objects.equals(item.getIdentifier(), identifierStr))//
+        .findFirst();
+    if (valueOpt.isPresent()) {
+      final String parentId = valueOpt.get().getValue();
+      return StringUtils.isBlank(parentId) ? Optional.empty() : Optional.of(parentId.strip());
+    }
+    return Optional.empty();
   }
 
   private static Map<String, String> buildMapCodelistIdToFilename(final Path pathFolder,

--- a/src/main/java/eu/europa/ted/eforms/viewer/SdkSymbolResolver.java
+++ b/src/main/java/eu/europa/ted/eforms/viewer/SdkSymbolResolver.java
@@ -18,7 +18,7 @@ import eu.europa.ted.efx.interfaces.SymbolResolver;
 import eu.europa.ted.efx.model.Expression.PathExpression;
 import eu.europa.ted.efx.xpath.XPathContextualizer;
 
-@VersionDependentComponent(versions = {"0.6", "0.7", "1"},
+@VersionDependentComponent(versions = {"1"},
     componentType = VersionDependentComponentType.SYMBOL_RESOLVER)
 public class SdkSymbolResolver implements SymbolResolver {
   protected Map<String, SdkField> fieldById;
@@ -44,8 +44,6 @@ public class SdkSymbolResolver implements SymbolResolver {
   }
 
   /**
-   * Private, use getInstance method instead.
-   *
    * @param sdkVersion The version of the SDK.
    * @throws InstantiationException
    */
@@ -56,9 +54,11 @@ public class SdkSymbolResolver implements SymbolResolver {
 
   protected void loadMapData(final String sdkVersion, final Path sdkRootPath)
       throws InstantiationException {
-    Path jsonPath = SdkResourceLoader.getResourceAsPath(sdkVersion,
+
+    final Path jsonPath = SdkResourceLoader.getResourceAsPath(sdkVersion,
         SdkConstants.SdkResource.FIELDS_JSON, sdkRootPath);
-    Path codelistsPath = SdkResourceLoader.getResourceAsPath(sdkVersion,
+
+    final Path codelistsPath = SdkResourceLoader.getResourceAsPath(sdkVersion,
         SdkConstants.SdkResource.CODELISTS, sdkRootPath);
 
     this.fieldById = new SdkFieldRepository(sdkVersion, jsonPath);
@@ -149,11 +149,21 @@ public class SdkSymbolResolver implements SymbolResolver {
   }
 
   @Override
-  public String getRootCodelistOfField(String fieldId) {
+  public String getRootCodelistOfField(final String fieldId) {
     final SdkField sdkField = fieldById.get(fieldId);
     if (sdkField == null) {
       throw new ParseCancellationException(String.format("Unknown field '%s'.", fieldId));
     }
-    return sdkField.getRootCodelistId();
+    final String codelistId = sdkField.getCodelistId();
+    if (codelistId == null) {
+      throw new ParseCancellationException(String.format("No codelist for field '%s'.", fieldId));
+    }
+
+    final SdkCodelist sdkCodelist = codelistById.get(codelistId);
+    if (sdkCodelist == null) {
+      throw new ParseCancellationException(String.format("Unknown codelist '%s'.", codelistId));
+    }
+
+    return sdkCodelist.getRootCodelistId();
   }
 }

--- a/src/main/java/eu/europa/ted/eforms/viewer/XslMarkupGenerator.java
+++ b/src/main/java/eu/europa/ted/eforms/viewer/XslMarkupGenerator.java
@@ -1,6 +1,5 @@
 package eu.europa.ted.eforms.viewer;
 
-import java.io.Writer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,7 +15,8 @@ import eu.europa.ted.efx.model.Expression.PathExpression;
 import eu.europa.ted.efx.model.Expression.StringExpression;
 import eu.europa.ted.efx.model.Markup;
 
-@VersionDependentComponent(versions = {"0.6", "0.7"}, componentType = VersionDependentComponentType.MARKUP_GENERATOR)
+@VersionDependentComponent(versions = {"1"},
+    componentType = VersionDependentComponentType.MARKUP_GENERATOR)
 public class XslMarkupGenerator extends IndentedStringWriter implements MarkupGenerator {
   private static final Logger logger = LoggerFactory.getLogger(XslMarkupGenerator.class);
 
@@ -26,8 +26,9 @@ public class XslMarkupGenerator extends IndentedStringWriter implements MarkupGe
     super(10);
   }
 
+  @SuppressWarnings("static-method")
   protected String[] getAssetTypes() {
-    return new String[]  {"business_term", "field", "code", "decoration"};
+    return new String[] {"business_term", "field", "code", "decoration"};
   }
 
   private final String translations = Arrays.stream(getAssetTypes())
@@ -97,13 +98,17 @@ public class XslMarkupGenerator extends IndentedStringWriter implements MarkupGe
     final String innerVariableName = String.format("label%d", variableCounter);
     writer.writeLine("");
     writer.openTag("span", "class=\"dynamic-label\"");
-    writer.openTag("xsl:variable", String.format("name=\"%s\" as=\"xs:string*\"", outerVariableName));
+    writer.openTag("xsl:variable",
+        String.format("name=\"%s\" as=\"xs:string*\"", outerVariableName));
     writer.openTag("xsl:for-each", String.format("select=\"%s\"", expression.script));
     writer.writeLine(String.format("<xsl:variable name=\"%s\" select=\".\"/>", innerVariableName));
-    writer.writeLine(String.format("<xsl:value-of select=\"($labels//entry[@key=$%s]/text(), concat('{', $%s, '}'))[1]\"/>", innerVariableName, innerVariableName));
+    writer.writeLine(String.format(
+        "<xsl:value-of select=\"($labels//entry[@key=$%s]/text(), concat('{', $%s, '}'))[1]\"/>",
+        innerVariableName, innerVariableName));
     writer.closeTag("xsl:for-each");
     writer.closeTag("xsl:variable");
-    writer.writeLine(String.format("<xsl:value-of select=\"string-join($%s, ', ')\"/>", outerVariableName));
+    writer.writeLine(
+        String.format("<xsl:value-of select=\"string-join($%s, ', ')\"/>", outerVariableName));
     writer.closeTag("span");
     return new Markup(writer.toString());
   }

--- a/src/main/java/eu/europa/ted/eforms/viewer/sdk1/XslMarkupGenerator.java
+++ b/src/main/java/eu/europa/ted/eforms/viewer/sdk1/XslMarkupGenerator.java
@@ -3,7 +3,8 @@ package eu.europa.ted.eforms.viewer.sdk1;
 import eu.europa.ted.eforms.sdk.selector.component.VersionDependentComponent;
 import eu.europa.ted.eforms.sdk.selector.component.VersionDependentComponentType;
 
-@VersionDependentComponent(versions = {"1"}, componentType = VersionDependentComponentType.MARKUP_GENERATOR)
+@VersionDependentComponent(versions = {"1"},
+    componentType = VersionDependentComponentType.MARKUP_GENERATOR)
 public class XslMarkupGenerator extends eu.europa.ted.eforms.viewer.XslMarkupGenerator {
 
 
@@ -13,6 +14,6 @@ public class XslMarkupGenerator extends eu.europa.ted.eforms.viewer.XslMarkupGen
 
   @Override
   protected String[] getAssetTypes() {
-    return new String[]  {"business-term", "field", "code", "auxiliary"};
+    return new String[] {"business-term", "field", "code", "auxiliary"};
   }
 }

--- a/src/test/java/eu/europa/ted/eforms/viewer/NoticeViewerTest.java
+++ b/src/test/java/eu/europa/ted/eforms/viewer/NoticeViewerTest.java
@@ -34,13 +34,13 @@ class NoticeViewerTest {
   private static final String[] SOURCE_NOTICE_XML_FILENAMES2 =
       new String[] {"X01_EEIG", "X02_registration"};
 
-  private static final String[] SOURCE_SDK_VERSIONS = new String[] {"0.7", "1.0"};
+  private static final String[] SOURCE_SDK_VERSIONS = new String[] {"1.0"};
 
   private static final Path SDK_RESOURCES_ROOT =
       Path.of("target", SdkConstants.DEFAULT_SDK_ROOT.toString());
 
   private static Stream<Arguments> provideArgsEfxToHtml() {
-    List<Arguments> arguments = new ArrayList<>();
+    final List<Arguments> arguments = new ArrayList<>();
     for (String language : SOURCE_LANGUAGES) {
       for (String noticeXmlFilename : SOURCE_NOTICE_XML_FILENAMES1) {
         for (String sdkVersion : SOURCE_SDK_VERSIONS) {
@@ -52,7 +52,7 @@ class NoticeViewerTest {
   }
 
   private static Stream<Arguments> provideArgsEfxToHtmlFromString() {
-    List<Arguments> arguments = new ArrayList<>();
+    final List<Arguments> arguments = new ArrayList<>();
     for (String language : SOURCE_LANGUAGES) {
       for (String noticeXmlFilename : SOURCE_NOTICE_XML_FILENAMES2) {
         for (String sdkVersion : SOURCE_SDK_VERSIONS) {
@@ -101,8 +101,8 @@ class NoticeViewerTest {
       final String sdkVersion)
       throws IOException, SAXException, ParserConfigurationException, InstantiationException {
     Path noticeXmlPath = getNoticeXmlPath(noticeXmlName, sdkVersion);
-    final Optional<String> viewIdOpt = Optional.empty(); // Equivalent to not
-                                                         // passing any in cli.
+    // Equivalent to not passing any in cli.
+    final Optional<String> viewIdOpt = Optional.empty();
     final Path path =
         NoticeViewer.generateHtml(language, noticeXmlPath, viewIdOpt, false, SDK_RESOURCES_ROOT);
     logger.info("TEST: Wrote html file: {}", path);
@@ -116,12 +116,16 @@ class NoticeViewerTest {
       final String viewId, final String sdkVersion)
       throws IOException, SAXException, ParserConfigurationException, InstantiationException {
     final Charset charsetUtf8 = StandardCharsets.UTF_8;
-    Path noticeXmlPath = getNoticeXmlPath(noticeXmlName, sdkVersion);
+
+    final Path noticeXmlPath = getNoticeXmlPath(noticeXmlName, sdkVersion);
     final String noticeXmlContent = Files.readString(noticeXmlPath, charsetUtf8);
+
     final Path xslPath = NoticeViewer.buildXsl(viewId, sdkVersion, SDK_RESOURCES_ROOT);
     final String xslContent = Files.readString(xslPath, charsetUtf8);
+
     final String html = NoticeViewer.generateHtml(language, noticeXmlContent, xslContent,
         charsetUtf8, Optional.of(viewId), false, SDK_RESOURCES_ROOT);
+
     logger.info("TEST: Wrote html {} ...", StringUtils.left(html, 50));
     assertTrue(StringUtils.isNotBlank(html));
     // The test would have failed if there were errors, this is what the check

--- a/src/test/java/eu/europa/ted/eforms/viewer/SdkSymbolResolverTest.java
+++ b/src/test/java/eu/europa/ted/eforms/viewer/SdkSymbolResolverTest.java
@@ -1,0 +1,49 @@
+package eu.europa.ted.eforms.viewer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import eu.europa.ted.eforms.sdk.SdkConstants;
+import eu.europa.ted.eforms.sdk.SdkVersion;
+import eu.europa.ted.eforms.sdk.resource.SdkDownloader;
+
+@Disabled // NOTE: this downloads an SDK.
+public class SdkSymbolResolverTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(SdkSymbolResolverTest.class);
+
+  private static final Path SDK_RESOURCES_ROOT =
+      Path.of("target", SdkConstants.DEFAULT_SDK_ROOT.toString());
+
+  @SuppressWarnings("static-method")
+  @Test
+  public void test() throws InstantiationException, IOException {
+    final Path sdkRootPath = SDK_RESOURCES_ROOT;
+
+    final SdkVersion sdkVersion = new SdkVersion("1.0");
+    SdkDownloader.downloadSdk(sdkVersion, sdkRootPath);
+
+    final SdkSymbolResolver resolver =
+        new SdkSymbolResolver(sdkVersion.toStringWithoutPatch(), sdkRootPath);
+
+    String fieldId = "BT-10-Procedure-Buyer";
+    final String rootCodelist = resolver.getRootCodelistOfField(fieldId);
+    logger.info("Found rootCodelist={} for field={}", rootCodelist, fieldId);
+    // 15:33:09.355 [main] INFO e.e.t.e.viewer.SdkSymbolResolverTest - Found
+    // rootCodelist=main-activity for field=BT-10-Procedure-Buyer
+
+    final String expected = "main-activity";
+
+    // The test works but the junit assert itself fails with:
+    // java.lang.NoClassDefFoundError: org/opentest4j/AssertionFailedError
+    // org.junit.jupiter.api.Assertions.assertEquals(expected, rootCodelist);
+
+    if (!expected.equals(rootCodelist)) {
+      throw new AssertionError(
+          String.format("Expected '%s' but found '%s'", expected, rootCodelist));
+    }
+  }
+}


### PR DESCRIPTION
…the genericode (gc). Fix in the loading of codelists in SdkCodelistRepository.
This was tested using SdkSymbolResolverTest but I disabled the test after that as it downloads an SDK.
