### PR TITLE
Added variable declarations to fragment_invocation.ftl.

### DIFF
--- a/src/main/resources/templates/xsl_markup/fragment_invocation.ftl
+++ b/src/main/resources/templates/xsl_markup/fragment_invocation.ftl
@@ -6,9 +6,12 @@
 -->
 
 <xsl:for-each select="${context}">
+    <#list variables as variable>
+        <xsl:variable name="${variable[0]}" select = "${variable[1]}" />
+    </#list>
 	<xsl:call-template name="${name}">
         <#list variables as variable>
-            <xsl:with-param name="${variable[0]}" select = "${variable[1]}" />
+            <xsl:with-param name="${variable[0]}" select = "$${variable[0]}" />
         </#list>
     </xsl:call-template>
 </xsl:for-each>


### PR DESCRIPTION
TEDEFO-3342 is a bug that talks about the need to declare XSL variables for each EFXT variable so that subsequently declared variables can reference previously declared ones. The previous implementation attempted to evaluate the variable initialisers directly when declared variables are passed as parameters to child EFX blocks. This does not allow referencing other variables in a variable initialiser because parameters cannot be referenced by name. The fix declares and initialises the variables before passing on their values to xsl:call-template as parameters.