### PR TITLE
Publish via the new Maven Central Portal

### DIFF
--- a/.github/workflows/settings.xml
+++ b/.github/workflows/settings.xml
@@ -4,7 +4,7 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>ossrh</id>
+      <id>central</id>
       <username>${env.MAVEN_USERNAME}</username>
       <password>${env.MAVEN_PASSWORD}</password>
     </server>
@@ -18,9 +18,9 @@
       </activation>
       <repositories>
         <repository>
-          <id>ossrh</id>
-          <name>OSSRH Snapshots</name>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+          <id>central-snapshots</id>
+          <name>Central Snapshots repository</name>
+          <url>https://central.sonatype.com/repository/maven-snapshots</url>
           <releases>
             <enabled>false</enabled>
           </releases>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ This project depends on both the eForms SDK and the EFX toolkit for Java, and us
 
 To build the application, open a terminal window and navigate to the root folder of this project. Then, run the following command:
 
-
 ```
 mvn clean install
 ```
@@ -39,14 +38,15 @@ mvn clean install -U
 
 This will force Maven to update any snapshots that are used as dependencies in the project.
 
-In order to be able to use \'xxx-SNAPSHOT\'[^1] versions of dependencies you will need to add the following repository in the **\<repositories\>** section in your settings.xml file:
+In order to be able to use \'xxx-SNAPSHOT\'[^1] versions of dependencies or of the eForms SDK you will need to add the following repository in the **\<repositories\>** section in your settings.xml file:
 
 [^1]: Release versions of the dependencies are provided by default in the maven central repo
-```
+
+```XML
 <repository>
-  <id>oss-snapshots</id>
-  <name>OSS Snapshots repository</name>
-  <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+  <id>central-snapshots</id>
+  <name>Central Snapshots repository</name>
+  <url>https://central.sonatype.com/repository/maven-snapshots</url>
   <releases>
     <enabled>false</enabled>
   </releases>
@@ -56,7 +56,7 @@ In order to be able to use \'xxx-SNAPSHOT\'[^1] versions of dependencies you wil
 </repository>
 ```
 
-## Usage    
+## Usage
 
 ### Requirements
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,17 +32,6 @@
     <url>https://github.com/OP-TED/eforms-notice-viewer.git</url>
   </scm>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <project.build.outputTimestamp>2024-08-02T13:11:16Z</project.build.outputTimestamp>
 
@@ -78,7 +67,7 @@
     <version.install.plugin>2.5.2</version.install.plugin>
     <version.javadoc.plugin>3.4.0</version.javadoc.plugin>
     <version.jar.plugin>3.2.2</version.jar.plugin>
-    <version.nexus-staging.plugin>1.6.7</version.nexus-staging.plugin>
+    <version.central-publishing.plugin>0.8.0</version.central-publishing.plugin>
     <version.shade.plugin>3.3.0</version.shade.plugin>
     <version.source.plugin>3.2.1</version.source.plugin>
     <version.surefire.plugin>3.2.5</version.surefire.plugin>
@@ -289,6 +278,20 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>central-snapshots</id>
+      <name>Central Snapshots repository</name>
+      <url>https://central.sonatype.com/repository/maven-snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -377,9 +380,9 @@
           <version>${version.source.plugin}</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${version.nexus-staging.plugin}</version>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${version.central-publishing.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -502,14 +505,13 @@
             </configuration>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <extensions>true</extensions>
-            <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            </configuration>
+            <groupId>org.sonatype.central</groupId>
+              <artifactId>central-publishing-maven-plugin</artifactId>
+              <extensions>true</extensions>
+              <configuration>
+                <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
+              </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Also add the definition of the repository to use for snapshot dependencies to pom.xml.
Update the definition of this snapshot repository in settings.xml. The settings.xml file is still needed, as it is used for downloading the eForms SDK when running the unit tests in the GitHub workflows.

Update README accordingly.